### PR TITLE
Pipeline Umgebung umbenannt und Track Promotion für Android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -77,3 +77,18 @@ jobs:
         packageName: dev.curth.hero
         releaseFiles: ./app-prod-release.aab
         track: internal
+       
+  production:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: [release]
+    environment:
+        name: Production
+    steps:
+    - name: Promote release to open testing
+      uses: kevin-david/promote-play-release@v1.0.0
+      with:
+        service-account-json-raw: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        package-name: dev.curth.hero
+        from-track: internal
+        to-track: beta

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment:
-        name: deploy_windows
+        name: Production
     if: ${{ github.event_name != 'pull_request' }}
     needs: [build]
     steps:


### PR DESCRIPTION
Die Umgebung wurde in "Production" umbenannt, um sie ebenfalls für Android zu nutzen.
Im Android-Workflow wurde ein weiterer Step eingebaut, der den Release in Open Testing promoted, wenn die Production-Umgebung freigegeben wird.