### PR TITLE
Textfelder im Charaktersheet innerhalb der Textbar korrekt schließen

### DIFF
--- a/Client/lib/src/features/characters/presentation/character_detail_screen.dart
+++ b/Client/lib/src/features/characters/presentation/character_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:keyboard_dismisser/keyboard_dismisser.dart';
 
 import '../../../common_widgets/content_tab.dart';
 import '../../../common_widgets/loading_indicator.dart';
@@ -123,24 +124,35 @@ class _CharacterDetailScreenState extends ConsumerState<CharacterDetailScreen> {
         )
     ];
 
-    return DefaultTabController(
-      length: tabs.length,
-      initialIndex: 0,
-      child: Scaffold(
-        appBar: AppBar(
-          actions: [
-            IconButton(icon: const Icon(Icons.refresh), onPressed: _refreshCharacter),
-          ],
-          bottom: 1 < tabs.length ? TabBar(tabs: tabs, isScrollable: true) : null,
+    return KeyboardDismisser(
+      child: DefaultTabController(
+        length: tabs.length,
+        initialIndex: 0,
+        child: Builder(
+          builder: (ctx) {
+            final controller = DefaultTabController.of(ctx);
+            controller.addListener(() {
+              FocusManager.instance.primaryFocus?.unfocus();
+            });
+
+            return Scaffold(
+              appBar: AppBar(
+                actions: [
+                  IconButton(icon: const Icon(Icons.refresh), onPressed: _refreshCharacter),
+                ],
+                bottom: 1 < tabs.length ? TabBar(tabs: tabs, isScrollable: true) : null,
+              ),
+              body: 1 < tabs.length
+                  ? NotificationListener<OverscrollIndicatorNotification>(
+                      onNotification: (OverscrollIndicatorNotification overScroll) {
+                        overScroll.disallowIndicator();
+                        return false;
+                      },
+                      child: TabBarView(children: [...tabs.map((e) => e.content)]))
+                  : tabs.first.content,
+            );
+          },
         ),
-        body: 1 < tabs.length
-            ? NotificationListener<OverscrollIndicatorNotification>(
-                onNotification: (OverscrollIndicatorNotification overScroll) {
-                  overScroll.disallowIndicator();
-                  return false;
-                },
-                child: TabBarView(children: [...tabs.map((e) => e.content)]))
-            : tabs.first.content,
       ),
     );
   }

--- a/Client/lib/src/features/characters/presentation/components/details/auto_saving_text_field.dart
+++ b/Client/lib/src/features/characters/presentation/components/details/auto_saving_text_field.dart
@@ -66,8 +66,10 @@ class _AutoSavingTextFieldState extends State<AutoSavingTextField> {
       },
       decoration: InputDecoration(
         border: widget.border,
+        alignLabelWithHint: true,
         label: Row(
           mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(widget.title),
             const SizedBox(width: 4),

--- a/Client/pubspec.lock
+++ b/Client/pubspec.lock
@@ -1239,6 +1239,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.12"
+  keyboard_dismisser:
+    dependency: "direct main"
+    description:
+      name: keyboard_dismisser
+      sha256: f67e032581fc3dd1f77e1cb54c421b089e015d122aeba2490ba001cfcc42a181
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   lints:
     dependency: transitive
     description:

--- a/Client/pubspec.yaml
+++ b/Client/pubspec.yaml
@@ -97,6 +97,7 @@ dependencies:
   timeago_flutter: ^3.4.0
   multiselect: ^0.1.0
   flutter_tagging_plus: ^4.0.1
+  keyboard_dismisser: ^3.0.0
 
 dependency_overrides:
   intl: ^0.18.0


### PR DESCRIPTION
Textfelder innerhalb der Tabbar im Charaktersheet werden nun korrekt geschlossen, wenn man das Tab wechselt oder außerhalb des Textfeldes klickt. fixed #81 