### PR TITLE
Erstellung von Ereignissen wieder möglich

### DIFF
--- a/Client/lib/src/features/admin/storyline/presentation/storyline_edit_screen.dart
+++ b/Client/lib/src/features/admin/storyline/presentation/storyline_edit_screen.dart
@@ -34,6 +34,7 @@ class _StorylineEditScreenState extends ConsumerState<StorylineEditScreen> {
   Future<StoryEntry?> _loadItem() async {
     if (null != widget.id) {
       final result = await ref.read(storyEntriesControllerProvider).getById(widget.id!);
+      if (!mounted) return null;
       setState(() {
         selectedType = StoryEntryType.values.byName(result.type);
       });

--- a/Client/lib/src/features/story/presentation/components/timeline_widget.dart
+++ b/Client/lib/src/features/story/presentation/components/timeline_widget.dart
@@ -34,7 +34,7 @@ class _TimelineWidgetState extends State<TimelineWidget> {
   @override
   Widget build(BuildContext context) {
     List<StoryEntryOverview> items = [...widget.entries];
-    items.sort((a, b) => a.order.compareTo(b.order));
+    items.sort((a, b) => b.order.compareTo(a.order));
 
     return SliverPadding(
       padding: const EdgeInsets.only(left: 12, top: 20, right: 12, bottom: 10),
@@ -64,7 +64,9 @@ class _TimelineWidgetState extends State<TimelineWidget> {
                         ),
                         child: Padding(
                           padding: const EdgeInsets.all(1),
-                          child: Center(child: AutoSizeText(items[i].date!, maxLines: 2, textAlign: TextAlign.center, minFontSize: 8)),
+                          child: null != items[i].date
+                              ? Center(child: AutoSizeText(items[i].date!, maxLines: 2, textAlign: TextAlign.center, minFontSize: 8))
+                              : null,
                         ),
                       ),
                     ),

--- a/Server/Hero.Server.DataAccess/Configurations/StoryEntryConfiguration.cs
+++ b/Server/Hero.Server.DataAccess/Configurations/StoryEntryConfiguration.cs
@@ -28,7 +28,6 @@ namespace Hero.Server.DataAccess.Configurations
             builder.Property(image => image.UpdatedAt)
                 .HasDefaultValueSql("now()");
 
-
             builder.Property(image => image.Order);
         }
     }
@@ -36,9 +35,7 @@ namespace Hero.Server.DataAccess.Configurations
     public class StoryImageModelConfiguration : IEntityTypeConfiguration<StoryImage>
     {
         public void Configure(EntityTypeBuilder<StoryImage> builder)
-        {
-            builder.Property(image => image.ImageUrl).IsRequired();
-        }
+        { }
     }
 
     public class StoryBookModelConfiguration : IEntityTypeConfiguration<StoryBook>

--- a/Server/Hero.Server.DataAccess/Migrations/20230418141810_StoryEntryImageUrlNullable.Designer.cs
+++ b/Server/Hero.Server.DataAccess/Migrations/20230418141810_StoryEntryImageUrlNullable.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Hero.Server.DataAccess.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hero.Server.DataAccess.Migrations
 {
     [DbContext(typeof(HeroDbContext))]
-    partial class HeroDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230418141810_StoryEntryImageUrlNullable")]
+    partial class StoryEntryImageUrlNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/Hero.Server.DataAccess/Migrations/20230418141810_StoryEntryImageUrlNullable.cs
+++ b/Server/Hero.Server.DataAccess/Migrations/20230418141810_StoryEntryImageUrlNullable.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hero.Server.DataAccess.Migrations
+{
+    public partial class StoryEntryImageUrlNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ImageUrl",
+                schema: "Hero",
+                table: "StoryEntries",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ImageUrl",
+                schema: "Hero",
+                table: "StoryEntries",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+    }
+}

--- a/Server/Hero.Server/Controllers/StoryController.cs
+++ b/Server/Hero.Server/Controllers/StoryController.cs
@@ -98,13 +98,14 @@ namespace Hero.Server.Controllers
         }
 
         [HttpPut("{id}"), IsGroupAdmin]
-        public async Task<IActionResult> UpdateStoryEntryAsync(Guid id, [FromBody] StoryEntryRequest request, CancellationToken cancellationToken = default)
+        public async Task<StoryEntryOverviewResponse> UpdateStoryEntryAsync(Guid id, [FromBody] StoryEntryRequest request, CancellationToken cancellationToken = default)
         {
             StoryEntry entry = this.ConvertEntry(request);
 
             await this.storyEntryRepository.UpdateAsync(id, entry, cancellationToken);
+            entry = await this.storyEntryRepository.GetByIdAsync(id, cancellationToken: cancellationToken);
 
-            return this.Ok(this.mapper.Map<StoryEntryOverviewResponse>(entry));
+            return this.mapper.Map<StoryEntryOverviewResponse>(entry);
         }
 
         [HttpDelete("{id}"), IsGroupAdmin]


### PR DESCRIPTION
Beim Erstellen von Ereignissen wurde in der Datenbank immer eine ImageUrl erwartet, für ein Ereignis wird jedoch kein Bild benötigt, wodurch das Speichern fehlschlug.
Ebenfalls wurde das Updaten von StoryEinträgen gefixt, sodass ein valider StoryEintrag vom  Server zurückgeliefert wird. 