### PR TITLE
Anzeigen von Talent aus Skill heraus

### DIFF
--- a/Client/lib/src/features/traits/presentation/components/ability_selection_field.dart
+++ b/Client/lib/src/features/traits/presentation/components/ability_selection_field.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_builder_extra_fields/form_builder_extra_fields.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../../kalinar_icons.dart';
 import '../../application/controller/abilities_controller.dart';
 import '../../domain/ability.dart';
 import '../../domain/suggestion_state.dart';
@@ -14,8 +15,9 @@ import '../edit_ability_screen.dart';
 
 class AbilitySelectionField extends ConsumerWidget {
   final Ability? initialValue;
+  final Function(Ability? item)? onSelectionChanged;
 
-  const AbilitySelectionField({this.initialValue, super.key});
+  const AbilitySelectionField({this.initialValue, this.onSelectionChanged, super.key});
 
   Future<void> _showAbilityScreen(BuildContext context) async {
     GoRouter.of(context).pushNamed(EditAbilityScreen.name);
@@ -30,7 +32,7 @@ class AbilitySelectionField extends ConsumerWidget {
             name: "abilityId",
             valueTransformer: (value) => value?.id,
             initialValue: initialValue,
-            decoration: InputDecoration(labelText: AppLocalizations.of(context)!.selectAnAbility, prefixIcon: const Icon(Icons.handyman)),
+            decoration: InputDecoration(labelText: AppLocalizations.of(context)!.selectAnAbility, prefixIcon: const Icon(Kalinar.star)),
             asyncItems: (text) async {
               final all =
                   await ref.read(abilitiesControllerProvider).search(query: text, allowedStates: [SuggestionState.approved, SuggestionState.pending]);
@@ -50,6 +52,7 @@ class AbilitySelectionField extends ConsumerWidget {
                 decoration: InputDecoration(border: const UnderlineInputBorder(), labelText: AppLocalizations.of(context)!.searchForAbility),
               ),
             ),
+            onChanged: onSelectionChanged,
           ),
         ),
         IconButton(

--- a/Client/lib/src/features/traits/presentation/edit_skill_screen.dart
+++ b/Client/lib/src/features/traits/presentation/edit_skill_screen.dart
@@ -3,12 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../common_widgets/form_fields/description_field.dart';
 import '../../../common_widgets/form_fields/image_picker_field.dart';
 import '../../../common_widgets/form_fields/invisible_field.dart';
 import '../../../common_widgets/form_fields/name_field.dart';
 import '../../group_management/application/group_notifier.dart';
+import '../application/controller/abilities_controller.dart';
 import '../application/controller/skills_controller.dart';
 import '../application/notifier/skill_state_notifier.dart';
 import '../domain/skill.dart';
@@ -16,6 +18,7 @@ import '../domain/suggestion_state.dart';
 import 'components/ability_selection_field.dart';
 import 'components/attributes_field.dart';
 import 'components/edit_view.dart';
+import 'edit_ability_screen.dart';
 
 class EditSkillScreen extends ConsumerStatefulWidget {
   static const String name = "EditSkill";
@@ -31,6 +34,8 @@ class EditSkillScreen extends ConsumerStatefulWidget {
 
 class _EditSkillScreenState extends ConsumerState<EditSkillScreen> {
   static final _formKey = GlobalKey<FormBuilderState>();
+
+  String? selectedAbilityId;
 
   bool _isCreatorOrAdminOrNew(Skill? item) {
     return widget.skillId == null ||
@@ -73,7 +78,18 @@ class _EditSkillScreenState extends ConsumerState<EditSkillScreen> {
             isLoading: state?.isLoading ?? false,
             initialValue: state?.valueOrNull?.description,
             readOnly: !_isCreatorOrAdminOrNew(state?.valueOrNull)),
-        AbilitySelectionField(initialValue: state?.valueOrNull?.ability),
+        AbilitySelectionField(initialValue: state?.valueOrNull?.ability, onSelectionChanged: (item) => setState(() => selectedAbilityId = item?.id)),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: TextButton(
+              onPressed: null != selectedAbilityId
+                  ? () {
+                      ref.read(abilitiesControllerProvider).getById(selectedAbilityId!);
+                      GoRouter.of(context).pushNamed(EditAbilityScreen.name, queryParams: {"id": selectedAbilityId});
+                    }
+                  : null,
+              child: Text(AppLocalizations.of(context)!.viewSelectedAbility)),
+        ),
         const SizedBox(height: 30),
         AttributesField(initialValue: state?.valueOrNull?.attributes),
       ],

--- a/Client/lib/src/localization/app_de.arb
+++ b/Client/lib/src/localization/app_de.arb
@@ -137,6 +137,7 @@
       }
     }
   },
+  "viewSelectedAbility": "Ausgewähltes Talent ansehen.",
   
   "passive": "Passiv",
 

--- a/Client/untranslated.json
+++ b/Client/untranslated.json
@@ -97,6 +97,7 @@
     "otherAbilities",
     "selectedTags",
     "abilitesCountInTag",
+    "viewSelectedAbility",
     "passive",
     "skillName",
     "skillDescription",


### PR DESCRIPTION
Ein neuer Button unter der Talentauswahl im SkillEditor eingeführt, welcher zur Talent-Bearbeitung des ausgewählten Talents führt. Dadurch kann eingesehen werden, welches Talent ausgewählt ist und ggf. auch direkt bearbeitet werden. Dies ist vor Allem für Vorschläge wichtig.